### PR TITLE
instarepo automatic PR

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Nikolaos Georgiou
+Copyright (c) 2021-2022 Nikolaos Georgiou
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.github.ngeor</groupId>
     <artifactId>java</artifactId>
-    <version>2.1.0</version>
+    <version>2.4.0</version>
   </parent>
   <artifactId>yak4j-utc-time-zone-mapper</artifactId>
   <version>0.18.0-SNAPSHOT</version>


### PR DESCRIPTION
The following fixes have been applied:
- chore: Updated copyright year in LICENSE
- chore(deps): Updating parent from 2.1.0 to 2.4.0
